### PR TITLE
Corrected name property to "name" for name input

### DIFF
--- a/stubs/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/stubs/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -20,7 +20,7 @@
                 </label>
 
                 <div class="col-md-6">
-                    <input id="name" type="text" class="form-control @error('name') is-invalid @enderror" name="email" value="{{ old('name', $user->name) }}" required autofocus autocomplete="name">
+                    <input id="name" type="text" class="form-control @error('name') is-invalid @enderror" name="name" value="{{ old('name', $user->name) }}" required autofocus autocomplete="name">
 
                     @error('name')
                         <span class="invalid-feedback" role="alert">


### PR DESCRIPTION
The property "name" on the profile page for updating the users name was set to email